### PR TITLE
fix: removed wildcard matching .ps1xml format files

### DIFF
--- a/PowerHTML.psd1
+++ b/PowerHTML.psd1
@@ -63,7 +63,7 @@ Description = 'Provides a wrapper for HTML Agility Pack for use where the IE HTM
 # TypesToProcess = @()
 
 # Format files (.ps1xml) to be loaded when importing this module
-FormatsToProcess = @('.\Types\*.ps1xml')
+FormatsToProcess = @('.\Types\HtmlAgilityPack.HtmlTextNode.ps1xml')
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 # NestedModules = @()


### PR DESCRIPTION
#8 fixes import issues when the current working directory has a Types folder with more than one .ps1xml file by removing the wildcard match